### PR TITLE
fix(deps): stop recurring bot PR build failures

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,16 @@
     {
       "matchDepTypes": ["devDependencies"],
       "automerge": true
+    },
+    {
+      "description": "Never automerge majors - they need a human to check the build.",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "description": "TypeScript 7 breaks next build, and the typescript-eslint toolchain bundled in eslint-config-next declares peer typescript '>=4.8.4 <6.1.0'. Revisit once both support TS 7.",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
     }
   ],
   "platformAutomerge": true,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,3 @@
-import tsEslint from "@typescript-eslint/eslint-plugin";
 import nextConfig from "eslint-config-next";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 
@@ -7,17 +6,23 @@ const config = [
   {
     files: ["**/*.{js,jsx,mjs,ts,tsx,mts,cts}"],
     plugins: {
-      "@typescript-eslint": tsEslint,
       "simple-import-sort": simpleImportSort,
     },
     rules: {
-      "@typescript-eslint/no-unused-vars": "error",
-      "@typescript-eslint/no-explicit-any": "error",
       quotes: "error",
       semi: "error",
       "semi-style": "error",
       "simple-import-sort/exports": "error",
       "simple-import-sort/imports": "error",
+    },
+  },
+  {
+    // The "@typescript-eslint" plugin is registered by eslint-config-next,
+    // which scopes it to TypeScript files only.
+    files: ["**/*.{ts,tsx,mts,cts}"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-explicit-any": "error",
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@types/node": "24.13.3",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
-        "@typescript-eslint/eslint-plugin": "8.54.0",
         "eslint": "9.39.5",
         "eslint-config-next": "16.2.10",
         "eslint-plugin-simple-import-sort": "14.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@types/node": "24.13.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
-    "@typescript-eslint/eslint-plugin": "8.54.0",
     "eslint": "9.39.5",
     "eslint-config-next": "16.2.10",
     "eslint-plugin-simple-import-sort": "14.0.0",


### PR DESCRIPTION
Two bot-opened PRs fail their builds on every attempt. This addresses both, and removes the root cause of the first rather than suppressing it.

## 1. `@typescript-eslint/eslint-plugin` (#1474, previously reverted in ed776c5 and 8659d1e)

`eslint-config-next` depends on `typescript-eslint`, which ships the plugin **and** parser as a version-matched set. `package.json` also pinned `@typescript-eslint/eslint-plugin` directly, so every bump made the plugin demand a newer parser than the config-next-owned one:

```
Conflicting peer dependency: @typescript-eslint/parser@8.64.0
  peer @typescript-eslint/parser@"^8.64.0" from @typescript-eslint/eslint-plugin@8.64.0
  typescript-eslint@"^8.46.0" from eslint-config-next@16.2.10
```

Renovate can't regenerate the lockfile, hence the `renovate/artifacts` failure. This recurs on *every* bump, which is why it's been reverted twice.

The direct dependency was redundant — `eslint-config-next` already registers the `@typescript-eslint` plugin. Removing it means the bot can no longer open this PR at all.

One wrinkle: `eslint-config-next` scopes that plugin to `**/*.ts` / `**/*.tsx` only, while our rules block covered `.js`/`.mjs` too. So the block is split rather than just trimmed. Verified both rules still fire:

```
1:7   error  'x' is assigned a value but never used  @typescript-eslint/no-unused-vars
1:20  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

## 2. `typescript` v7 (#1488)

No workaround available. With TS pinned to 7.0.2 (verified installed before and after), `next build` fails:

```
The "id" argument must be of type string. Received undefined
Next.js build worker exited with code: 1
```

It's blocked on two fronts — `@typescript-eslint/tsconfig-utils` also declares peer `typescript@">=4.8.4 <6.1.0"`, so the eslint toolchain excludes TS 7 regardless of Next. Constrained to `<7` in `renovate.json` with a note to revisit.

Note `recreateWhen: "never"` alone wouldn't have held: it only stops a *closed* PR reappearing for the same version, not a fresh one for 7.0.3. The `allowedVersions` constraint is what makes it durable.

## Also

Majors are no longer automerged. The existing `matchDepTypes: ["devDependencies"] -> automerge: true` rule applied to majors too, so the TS 7 bump was queued to automerge into `main`.

## Verification

- `npm run lint` — clean, rules confirmed still enforced
- `npm run build` — passes
- `renovate-config-validator` — "Config validated successfully"

Not touched: #1477 (browserslist) is not failing, just `BEHIND` and superseded; the action reuses its branch and self-corrects.

## Follow-up (not in this PR)

`next build` rewrites `tsconfig.json` (`jsx: preserve` -> `react-jsx`) and `next-env.d.ts` on every run — pre-existing drift from the Next 16 upgrade, reverted here to keep the diff focused. Worth a separate PR.

Once this lands, #1474 can be closed (the dependency no longer exists) and Renovate should auto-close #1488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
