### PR TITLE
fix(deps): block eslint v10 until the Next plugin stack supports it

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,11 @@
       "description": "TypeScript 7 breaks next build, and the typescript-eslint toolchain bundled in eslint-config-next declares peer typescript '>=4.8.4 <6.1.0'. Revisit once both support TS 7.",
       "matchPackageNames": ["typescript"],
       "allowedVersions": "<7"
+    },
+    {
+      "description": "eslint 10 breaks the plugin stack bundled in eslint-config-next: eslint-plugin-react fails with 'contextOrFilename.getFilename is not a function', and .mjs files fail with 'scopeManager.addGlobals is not a function'. Revisit once eslint-config-next ships eslint 10 support.",
+      "matchPackageNames": ["eslint"],
+      "allowedVersions": "<10"
     }
   ],
   "platformAutomerge": true,


### PR DESCRIPTION
Follow-up to #1500, from reviewing the blocked PRs on the Dependency Dashboard (#32).

## Why

eslint 10 breaks linting entirely. Tested on current `main`, two separate failures:

```
eslint.config.mjs -> TypeError: scopeManager.addGlobals is not a function
src/**/*.tsx      -> Error while loading rule 'react/display-name':
                     contextOrFilename.getFilename is not a function
```

The second is the real blocker: `eslint-plugin-react`, bundled inside `eslint-config-next`, hasn't adapted to the eslint 10 context API. This needs upstream releases — there's no local workaround.

Worth noting `typescript-eslint@8.64.0` *declares* peer `eslint: "^10.0.0"`, so the declared peer ranges look satisfiable and `npm install` succeeds. The incompatibility only surfaces at runtime, which is why this can't be caught by resolution alone.

#1467 was closed for this, but is currently held only by `recreateWhen: "never"` plus a dashboard checkbox — one accidental tick and it's back. The constraint makes it durable and records *why*, mirroring the `typescript` `<7` rule from #1500.

## Scoping

Uses an exact package-name match. The `"/eslint/"` regex rule above it intentionally matches all eslint-* packages for labelling; this one must not, or it would block `eslint-plugin-simple-import-sort` (currently at 14.0.0) and `eslint-config-next` (16.2.10). Plain strings are exact matches in Renovate, so those are unaffected.

## Verification

`renovate-config-validator` — "Config validated successfully"

## Related: TypeScript v6 (#1410) is now unblocked

The other blocked PR on the dashboard was closed with the same `renovate/artifacts` signature that #1500 fixed — it was collateral damage from the `@typescript-eslint/eslint-plugin` pin, not a real incompatibility.

Re-tested on post-#1500 `main` with `typescript` pinned to 6.0.3 (verified installed before and after the build): `npm install` clean with no ERESOLVE, `npm run build` passes, `npm run lint` clean.

TS 6 also sits inside the existing `<7` constraint, so ticking the recreate box on the dashboard should now produce a green PR. Not included here — that's Renovate's to open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
