### PR TITLE
fix: commit Next 16 tsconfig migration and untrack next-env.d.ts

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -32,7 +32,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
`next build` rewrote two tracked files on every single run, leaving the working tree dirty:

```
tsconfig.json:  "jsx": "preserve" -> "react-jsx"
                include: + ".next/dev/types/**/*.ts"
next-env.d.ts:  /// <reference path="./.next/types/routes.d.ts" />
                -> import "./.next/types/routes.d.ts";
```

## Why it was stuck

Both files were last touched in `bc5d77b`, which **predates** the Next 15 -> 16 upgrade in `eb443e4`.

Renovate upgraded Next by editing `package.json` and the lockfile — all it can do. It can't run `next build` and commit the resulting config migration. So Next 16 re-applied the migration on every build and nothing ever wrote it back. Same shape as the stale lockfile in #1503: a bot bumped a version, but the side effects of that bump were never committed.

## Two files, two fixes

**`tsconfig.json` — commit the migration.** It's legitimately tracked. `jsx: react-jsx` is what Next 16 reports as a *mandatory* change ("next.js uses the React automatic runtime"). The `.next/dev/types` include is dev-server-only, which is why Next reports it as *suggested* rather than mandatory.

**`next-env.d.ts` — untrack it.** It already matches `.gitignore:36`:

```
$ git check-ignore -v --no-index next-env.d.ts
.gitignore:36:next-env.d.ts	next-env.d.ts
```

That's the create-next-app default, since Next regenerates the file on every build. But it was committed anyway, and git ignore rules don't apply to tracked files — so that rule has been inert since `401e3b4`. `git rm --cached` makes the existing intent effective. The file stays on disk and is still regenerated.

## Was anything broken?

No. CI builds from a fresh checkout, rewrites the files, and never diffs them — Vercel has been green throughout. This is purely to stop local churn, which is noise on every build and the kind of thing that eventually gets swept into an unrelated commit.

## Verification

- `tsc --noEmit` — exit 0, both before and after the change
- `npm run lint` — clean
- **Idempotency**: `rm -rf .next` then two consecutive builds — no reconfiguration message, tree stays clean
- **Fresh-clone safety**: deleted `next-env.d.ts` entirely and built — Next regenerated it correctly with the expected contents

On that last point, since a fresh clone no longer gets the file, I checked that nothing typechecks without building first: CodeQL uses autobuild, the Dockerfile runs `npm ci && npm run build`, Vercel runs `next build`. All regenerate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
